### PR TITLE
Fix sort order when sorting numbers desc

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,12 +1,11 @@
 {
   "name": "natural-sort",
-  "repo": "javve/natural-sort",
+  "repo": "ashfordl/natural-sort",
   "description": "Natural sort algorithm with unicode support",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": ["natural sort", "sort", "unicode", "dates"],
   "scripts": [
     "index.js"
   ],
-  "twitter": "@javve",
   "license": "MIT"
 }

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function(a, b, options) {
     oFxNcL = !(xN[cLoc] || '').match(ore) && parseFloat(xN[cLoc]) || xN[cLoc] || 0;
     oFyNcL = !(yN[cLoc] || '').match(ore) && parseFloat(yN[cLoc]) || yN[cLoc] || 0;
     // handle numeric vs string comparison - number < string - (Kyle Adams)
-    if (isNaN(oFxNcL) !== isNaN(oFyNcL)) { return (isNaN(oFxNcL)) ? 1 : -1; }
+    if (isNaN(oFxNcL) !== isNaN(oFyNcL)) { return mult * ((isNaN(oFxNcL)) ? 1 : -1); }
     // rely on string comparison if different types - i.e. '02' < 2 != '02' < '2'
     else if (typeof oFxNcL !== typeof oFyNcL) {
       oFxNcL += '';


### PR DESCRIPTION
Previously, numbers would ignore the desc option. This change rectifies this.